### PR TITLE
Fix doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 A previewer for ddc.vim in Neovim.
 
-See [doc](./doc/ddc-preview.txt) for defails.
+See [doc](./doc/ddc-previewer-floating.txt) for defails.
 
 ![ss](https://github.com/uga-rosa/ddc-preview.nvim/assets/82267684/5aa95908-b981-4eeb-b437-b6c155f4ba16)


### PR DESCRIPTION
The link to the documentation was broken and has been corrected.