### PR TITLE
fix: Error will be occurred with native popupmenu

### DIFF
--- a/lua/ddc_previewer_floating/utils.lua
+++ b/lua/ddc_previewer_floating/utils.lua
@@ -43,4 +43,10 @@ function M.debounse(name, fn, time)
   )
 end
 
+---@param x any
+---@return boolean
+function M.is_truthy(x)
+  return 0 == vim.fn.empty(x)
+end
+
 return M

--- a/lua/ddc_previewer_floating/view.lua
+++ b/lua/ddc_previewer_floating/view.lua
@@ -65,7 +65,10 @@ end
 function View:_open(item)
   local pum_pos = pum.get_pos()
   local row = pum_pos.row
-  local col = pum_pos.col + pum_pos.width + pum_pos.scrollbar
+  local col = pum_pos.col + pum_pos.width
+  if utils.is_truthy(pum_pos.scrollbar) then
+    col = col + 1
+  end
   local max_width = config.get("max_width")
   local max_height = config.get("max_height")
   ---@type PreviewContext


### PR DESCRIPTION
Problem: An error occurs when displaying a preview. It's caused by a difference between |pum_getpos()| and |pum#getpos()|. It is a type mismatch of `scrollbar` field. The field is defined as |TRUE| in their documentation. However, it is used as integer in View:_win_open() function.

Solution: Check `scrollbar` field by |empty()| that it's |TRUE|.